### PR TITLE
added epub format

### DIFF
--- a/fundamentals/Makefile
+++ b/fundamentals/Makefile
@@ -17,8 +17,14 @@ all-via-dvi:
 	latex $(latexopt) $(manuscript)
 	dvipdf $(manuscript)
 
+epub: 
+	latex $(latexopt) $(manuscript)
+	bibtex $(manuscript).aux
+	mk4ht htlatex $(manuscript).tex 'xhtml,charset=utf-8,pmathml' ' -cunihtf -utf8 -cvalidate'
+	ebook-convert $(manuscript).html $(manuscript).epub
+
 clean:
-	rm -f *.pdf *.dvi *.toc *.aux *.out *.log *.bbl *.blg *.log *.spl *~ *.spl *.zip *.acn *.glo *.ist
+	rm -f *.pdf *.dvi *.toc *.aux *.out *.log *.bbl *.blg *.log *.spl *~ *.spl *.zip *.acn *.glo *.ist *.epub
 
 realclean: clean
 	rm -rf $(manuscript).dvi


### PR DESCRIPTION
Allows building in epub format that preserves math.  Based on instructions here: http://tex.stackexchange.com/a/17842  Also, I found this awesome super minimal epub reader: 

`unzip -p book.epub | strings | less`
