### PR TITLE
PPHW

### DIFF
--- a/fundamentals/impl.tex
+++ b/fundamentals/impl.tex
@@ -20,8 +20,6 @@ resources and materials and time via the \gls{DRE}.
 Support for users and developers via the \Cycamore library of
 archetypes and the experimental toolkit are also presented.
 Lastly, the methods for quality assurance are outlined.
-These features provide a solid foundation on which to build an interconnected community 
-of archetype developers with diverse backgrounds and simulation goals.
 
 \subsection{Modular Software Architecture}
 % Motivation for encapsulated plug-in architecture 
@@ -393,7 +391,7 @@ occurs. \TODO{do we want a diagram helping show this composition caching?}
 \TODO{This is SO for you, Matt Gidden!}
 Placeholder as a reminder to add more detail about this.
 
-\subsection{Simulation Assistance}
+\subsection{Simulation Support}
 So that users and developers can build working simulations
 in the shortest time possible, the \Cyclus ecosystem provides the fundamental 
 building blocks: basic archetypes and a toolkit of commonly needed functions.

--- a/fundamentals/impl.tex
+++ b/fundamentals/impl.tex
@@ -50,9 +50,11 @@ developed and interchanged while keeping the rest of the fuel cycle fixed
 
 \subsubsection{Cluster-Ready Software}
 
-Many fuel cycle simulators rely on \gls{COTS} and Windows-only software that limits 
+Groundbreaking insights and new classes of problems can be investigated by 
+leveraging modern massive computing resources.
+However, many fuel cycle simulators rely on \gls{COTS} and Windows-only software that limits 
 performance on and compatibility with resource computing infrastructures. This limitation severely 
-increases the wall-clock time necessary to conduct parameterized sensitivity 
+limits the possible scope of simulations and increases the wall-clock time necessary to conduct parameterized sensitivity 
 analyses and other multi-simulation studies. \Cyclus, on the other hand, is 
 primarily written in \texttt{C++} and relies on 
 libraries supported by Linux and UNIX (including Ubuntu and OSX) platforms, 
@@ -72,24 +74,23 @@ also been utilized to run and collect information from full \Cyclus simulations
 running in parallel on $10^3$ machines reliably for order $10^5$ simulations.
 
 \subsubsection{Dynamically Loadable Libraries}
-% (diagram)
 
-A key innovation is that \Cyclus  implements this generic \gls{API} and modular 
-architecture via a suite of dynamically loadable plug-in libraries.  Though 
-common in modern software architecture, such a plug-in pattern has 
-not previously been implemented in nuclear fuel cycle simulators.  
-Dynamically loadable libraries are the primary mechanism for extending \Cyclus' capability. This approach provides encapsulation: the core of the code operates
-independently from the individual plug-in libraries. Thus, any
-customization or extension is implemented only in the loadable
-library. 
-
-This approach encourages efficient, targeted contribution to the ecosystem of 
-archetype libraries.  The 
-researcher can focus on generating an archetype model within their
+The \Cyclus architecture encourages efficient, targeted contribution to the ecosystem of 
+archetype libraries.
+With \Cyclus, a researcher can focus on generating an archetype model within their
 sphere of expertise, while relying on the contributions of others to fill 
-in the other technologies in the simulation.  This strategy also allows individual developers to
-explore different levels of complexity within their archetypes, including
+in the other technologies in the simulation.  
+Similarly, individual developers may explore different levels of complexity within their archetypes, including
 wrapping other simulation tools as loadable libraries within \Cyclus.
+
+\Cyclus acheives this behavior by implementing its generic \gls{API} and 
+modular architecture via a suite of dynamically loadable plug-in libraries.  
+Though common in modern software architecture, such a plug-in pattern has not 
+previously been implemented in nuclear fuel cycle simulators.  Dynamically 
+loadable libraries are the primary mechanism for extending \Cyclus' capability. 
+This approach provides encapsulation: the core of the code operates 
+independently from the individual plug-in libraries. Thus, any customization or 
+extension is implemented only in the loadable library.  
 
 \begin{figure}[htbp!]
 \begin{center}
@@ -368,11 +369,11 @@ developers to choose how to handle potentially full-fidelity compositions.
 
 In large simulations many material objects may be changing frequently.
 Material decay can also contribute significantly to such changes.  In order to
-help avoid unnecessary runtime performance and database space impacts,
+help avoid unnecessary runtime performance and database size impacts,
 compositions in \Cyclus have some special features.
 Immutability of compositions allows multiple material objects to all hold
-references to the same composition object safely.  When operations are
-performed on a material that do not alter the composition, any new resulting
+references to the same composition object safely.  When operations that do not 
+alter the composition are performed on a material, any new resulting
 materials hold a reference to the same, original composition object.
 Although the decay operation generates a new, separate composition (preserving
 immutability), a reference to the new composition is placed in a cache shared

--- a/fundamentals/intro.tex
+++ b/fundamentals/intro.tex
@@ -139,22 +139,24 @@ and regions greatly improves upon the existing fuel cycle simulators.
 
 In addition to providing the fundamental features expected in fuel cycle 
 simulators, the \Cyclus paradigm enables essential capabilities that previous 
-simulators lack. Critically, its \emph{modular and open architecture}  facilitates 
-targeted contribution and collaboration within the nuclear fuel cycle analysis 
-community.  Additionally, \emph{agent interchangeability} facilitates direct 
-comparison of modeling methodologies. Finally, the flexibility and generality 
+simulators lack. Critically, targeted contribution and collaboration within the nuclear fuel cycle analysis 
+community are assisted by the \emph{modular and open architecture} of \Cyclus.
+Additionally, \Cyclus facilitates direct comparison of modeling methodologies with 
+\emph{agent interchangeability}.
+Finally, \Cyclus is applicable to a broader range of 
+fidelities, scales, and applications than other simulators. 
+due to the flexibility and generality 
 of its \emph{\gls{ABM}} paradigm and \emph{discrete, object-oriented approach} 
-enables \Cyclus to be applicable to a broader range of 
-fidelities, scales, and applications than to other simulators. 
 
-\Cyclus separates the problem of modeling a
+Specialists in a given field should utilize their time and resources in 
+modeling the specific processes associated with their area of expertise within 
+thenuclear fuel cycle (e.g., reprocessing and advanced
+fuel fabrication), without having to model the entirety of the cycle.
+\Cyclus supports them by separating the problem of modeling a
 physics-dependent supply chain into two distinct components: a simulation kernel and archetypes that
 interact with the kernel. The kernel is responsible for the
 deployment and interaction logic of entities in the simulation.  Physics calculations and 
-customized behaviors are implemented within archetypes. Accordingly, specialists
-in a given field can utilize their time and resources in modeling a specific
-process associated with the nuclear fuel cycle (e.g., reprocessing and advanced
-fuel fabrication), without having to model the entirety of the cycle.
+customized behaviors are implemented within archetypes. 
 
 Furthermore, modeling the evolution of a physics-dependent, international nuclear fuel supply
 chain is a multiscale problem, and existing tools are not sufficiently 

--- a/fundamentals/intro.tex
+++ b/fundamentals/intro.tex
@@ -13,15 +13,22 @@
 % What should the reader expect as conclusion?
 
 
-As nuclear power expands both domestically and internationally, nuclear fuel cycle
-performance analysis on technical, economic, political, and environmental axes increases 
-in importance. Appropriate nuclear fuel cycle analysis requires calculation of myriad physical, nuclear, 
-chemical, industrial, and political phenomena. Nuclear fuel cycle simulators 
-therefore couple complex systems such as nuclear process physics, 
-facility deployment, and material routing. However, most nuclear fuel cycle 
-simulators have not incorporated modern insights from simulation science and 
-software architecture that can enable more efficient, accurate, robust, and 
-validated analysis. 
+As nuclear power expands both domestically and internationally, nuclear fuel
+cycle performance analysis on technical, economic, political, and environmental
+axes increases in importance. Appropriate nuclear fuel cycle analysis requires
+calculation of myriad physical, nuclear, chemical, industrial, and political
+phenomena. Nuclear fuel cycle simulators therefore couple complex systems such
+as nuclear process physics, facility deployment, and material routing.
+However, current fuel cycle simulators rely on closed platforms and inflexible
+architectures which exhibit three main failure modes. First, they discourage
+targeted contribution and collaboration among experts. Next, they hobble
+efforts to directly comparison of modeling methodologies. Finally, they result
+in over-specification, rendering most tools applicable to only a subset of
+desired simulation fidelities, scales, and applications.  A next generation
+fuel cycle simulator is needed which incorporates modern insights from
+simulation science and software architecture to solve these problems. As a
+bonus, many of these methods simultaneously enable more efficient, accurate,
+robust, and validated analysis. 
 
 The \Cyclus nuclear fuel cycle simulator framework and 
 its modeling ecosystem address this need for a next-generation nuclear fuel cycle 

--- a/fundamentals/intro.tex
+++ b/fundamentals/intro.tex
@@ -22,22 +22,22 @@ as nuclear process physics, facility deployment, and material routing.
 However, current fuel cycle simulators rely on closed platforms and inflexible
 architectures which exhibit three main failure modes. First, they discourage
 targeted contribution and collaboration among experts. Next, they hobble
-efforts to directly comparison of modeling methodologies. Finally, they result
-in over-specification, rendering most tools applicable to only a subset of
-desired simulation fidelities, scales, and applications.  A next generation
-fuel cycle simulator is needed which incorporates modern insights from
-simulation science and software architecture to solve these problems. As a
-bonus, many of these methods simultaneously enable more efficient, accurate,
+efforts to directly compare modeling methodologies. Finally, they 
+over-specialize, rendering most tools applicable to only a subset of
+desired simulation fidelities, scales, and applications.
+The \Cyclus nuclear fuel cycle simulator framework and 
+its modeling ecosystem incorporate modern insights from
+simulation science and software architecture to solve these problems. 
+As a bonus, many of these methods simultaneously enable more efficient, accurate,
 robust, and validated analysis. 
 
-The \Cyclus nuclear fuel cycle simulator framework and 
-its modeling ecosystem address this need for a next-generation nuclear fuel cycle 
-simulator. This dynamic simulator employs discrete agents, time, and isotopic resolution of materials 
-and supports a range of analysis types, levels of 
-detail, and analyst sophistication.
-Additionally, \Cyclus employs a modular architecture and 
-open development process that supports user access and 
-encourages developer extensions.
+The \Cyclus next-generation fuel cycle simulator is the result of design 
+choices made explicitly to:
+\begin{itemize}
+\item support user access and encourages developer extensions,
+\item enable plug-and-play comparison of modeling methodologies,
+\item and address a range of analysis types, levels of detail, and analyst sophistication.
+\end{itemize}
 
 Historically, nuclear fuel cycle simulators have estimated 
 nuclear fuel cycle performance using software 
@@ -47,11 +47,14 @@ proprietary models. To date, current tools are either static, fleet-based,
 privately distributed, or all of the above. Each of these qualities presents a 
 severe challenge to modeling fidelity, generality, efficiency, robustness, and 
 scientific transparency. 
-
 An alternative to these approaches is a dynamic, agent-based simulator with an 
 open platform and an ecosystem of research-driven capabilities.  
-Dynamic nuclear fuel cycle analysis more realistically 
-supports a range of simulation goals than static analysis 
+
+\Cyclus, therefore, is a dynamic, agent-based model, which employs a modular 
+architecture, an open development process, discrete agents, discrete time, and 
+arbitrarily detailed isotopic resolution of materials.  Dynamic nuclear fuel 
+cycle analysis more realistically supports a range of simulation goals than 
+static analysis 
 \cite{piet_dynamic_2011}. Similarly, experience in the broader field of systems 
 analysis indicates that agent-based modeling enables more flexible simulation 
 control, without loss of generality \cite{macal_agent-based_2010}. Finally, openness 
@@ -86,23 +89,7 @@ lifetime fuel costs and electricity generation,
 while environmental performance might be measured in spent fuel volume, 
   toxicity, or mined uranium.
 
-Historically, the national laboratories have driven development and regulated 
-the use of their own tools: \gls{VISION}\cite{jacobson_verifiable_2010}, 
-\gls{DANESS}\cite{van_den_durpel_daness_2009}, 
-\gls{DYMOND}\cite{yacout_modeling_2005}, and 
-\gls{NFCSim}\cite{schneider_nfcsim:_2005}. 
-Outside the national laboratories, researchers have created new nuclear fuel cycle 
-simulation tools when existing tools were not available or not sufficiently 
-general to calculate their metrics of interest with their method of choice.  
-With limited access to the national laboratory tools and a need to customize 
-them for research purposes, universities and private industry researchers have 
-``reinvented the wheel'' by developing tools of their own from scratch and 
-tailored to their own needs, for example \gls{CAFCA}\cite{guerin_impact_2009} and 
-\gls{COSI}\cite{boucher_cosi_2005,boucher_cosi:_2006,meyer_new_2009,coquelet-pascal_comparison_2011}. 
-
-This trend has resulted in a proliferation of specialized
-fuel cycle simulators for the calculation of fuel cycle metrics.  Accordingly, methods 
-for calculating those metrics vary among simulators. Some model the 
+However, methods for calculating those metrics vary among simulators. Some model the 
 system of facilities, economics, and materials in static equilibrium, while 
 other simulators capture the dynamics of the system.  
 Similarly, while some simulators discretely model material and facilities, 
@@ -113,7 +100,22 @@ others. For example, a simulator created for policy modeling might have excellen
 capability in economics while material isotopics and transmutation detail are 
 neglected.
 
-\Cyclus emerged from a line of tools seeking to break this practice.  
+This overspecialization and fractured community is the result of history. 
+Historically, the national laboratories have driven development and regulated 
+the use of their own tools: \gls{VISION}\cite{jacobson_verifiable_2010}, 
+\gls{DANESS}\cite{van_den_durpel_daness_2009}, 
+\gls{DYMOND}\cite{yacout_modeling_2005}, and 
+\gls{NFCSim}\cite{schneider_nfcsim:_2005}.  Outside the national laboratories, 
+researchers have created new nuclear fuel cycle simulation tools when existing 
+tools were not available or not sufficiently general to calculate their metrics 
+of interest with their method of choice.  With limited access to the national 
+laboratory tools and a need to customize them for research purposes, 
+universities and private industry researchers have ``reinvented the wheel'' by 
+developing tools of their own from scratch and tailored to their own needs, for 
+example \gls{CAFCA}\cite{guerin_impact_2009} and 
+\gls{COSI}\cite{boucher_cosi_2005,boucher_cosi:_2006,meyer_new_2009,coquelet-pascal_comparison_2011}. 
+
+\Cyclus emerged from a line of tools seeking to break this practice. 
 Its precurser,
 \gls{GENIUSv1}\cite{dunzik-gougar_global_2007,jain_transitioning_2006}, began
 at \gls{LDRD} within \gls{INL} and sought 


### PR DESCRIPTION
Ok, so @gonuke had a suggestion:


> Each time I'm left with the same sense that it leada with the software technology rather than with the fuel cycle analysis capabilities. 
> ...
> If we are to target the journals that we have discussed to date, [...], the primary readers of that publication will need to recognize its importance.  That said, Cyclus' biggest contributions and innovations so far, are the software technologies that we've put together.  Our challenge, then, is to draw a line between each of the technological innovations and an (easily) recognizable capability that it enables.  
>
> Most importantly, the motivation needs to be "doing better fuel cycle analysis" and not "a more modern fuel cycle simulator".  We can still discuss all the same software innovations, but we need to "trick" the reader into reading about them, and do so in a way that makes sense to them. I revised the motivational  language in the paper (mostly the introductions to the various sections) to emphasize the simulation needs rather than the software solutions.

I made some changes, mostly to the introductory sections, that flipped the presentation. I gave motivations before implementations... where previously most sentences had it the other way around.
Do you think you have time to look over this PR, @gonuke, to see if it helps with your feeling there?
If not, no big deal. I think it's probably improvement in any case. 