### PR TITLE
PPHW 2: Substantial changes to Motivation

### DIFF
--- a/fundamentals/fcsreqs.tex
+++ b/fundamentals/fcsreqs.tex
@@ -1,4 +1,52 @@
 
+\subsubsection{Open Access and Development Practices}
+
+The proprietary concerns of research institutions and security constraints of
+data within fuel cycle simulators often restrict access. Use of a simulator is
+therefore often limited to its institution of origin, necessitating effort
+duplication at other institutions and thereby squandering broader human
+resources. License agreements and institutional approval are required for most
+current simulators (i.e. \gls{COSI}6, \gls{DANESS}, \gls{DESAE}, EVOLCODE,
+FAMILY21, \gls{NFCSim})\cite{juchau_modeling_2010}, ORION, and VISION.  Even when, as in
+the case of the MIT \gls{CAFCA} software, the source code is unrestricted, the
+platform on which it relies is often restricted or costly.  However, \Cyclus
+provides fully free and open access to all users
+and developers, foreign and domestic.
+
+Moreover, both technical and institutional aspects of the software development
+practices employed by the \Cyclus community faciltate collaboration.
+Technically, \Cyclus employs a set of tools commonly used collaborative
+software development that reduce the effort required to comment on, test and
+ultimately merge individual contributions into the main development path.  
+For many of the simulation platforms adopted by previous simulators, there were
+technical obstacles that impeded this kind of collaboration.
+Institutionally, \Cyclus invites all participants to propose, discuss and
+provide input to the final decision making for all important changes.
+
+\subsubsection{Modularity and Extensibility}
+
+Modularity is a key enabler of extending the scope of fuel cycle analysis
+within the \Cyclus framework.  Changes that are required to improve the
+fidelity of modeling a paticular agent, or to introduce entirely new agents,
+are narrowly confined and place no new requirements on the \Cyclus kernel.
+Furthermore, there are very few assumptions or heuristics that would otherwise
+restrict the algorithmic complexity that can be used to model the behavior of
+such agents.
+
+For example, most current simulators describe a finite set of acceptable cycle
+constructions (once through, single-pass, multi-pass). That limits the
+capability to create novel material flows and economic scenarios. The \Cyclus
+simulation logic relies on a market paradigm, parameterized by the user, which
+flexibly simulates dynamic responses to pricing, availability, and other
+institutional preferences.  
+
+This minimal set of mutual dependencies between the kernel and the agents is
+expressed through the \gls{DRE} that provides a level of flexibility that does
+not exist in other fuel cycle simulators.  It creates the potential for novel
+agent archetypes to interact with existing archetypes as they enter and leave
+the simulation over time and seek to trade materials whose specific
+composition may not be known \textit{a priori}.
+
 \subsubsection{Discrete Facilities and Materials}
 
 Many fuel cycle phenomena have aggregate system-level effects which can only be
@@ -15,7 +63,8 @@ Similarly, the ability to model disruptions (i.e. facility shutdowns due to
 insufficient feed material or insufficient processing and storage capacity) is
 most readily captured by software capable of tracking the operations status of
 discrete facilities \cite{huff_next_2010}.  Fleet-based models (i.e.
-\gls{VISION}) are unable to capture this gracefully.  All of the software
+\gls{VISION}) are unable to capture this gracefully, perhaps representing it as 
+a reduction in the capacity of the whole fleet.  All of the software
 capable of discrete materials have a notion of discrete facilities, however not
 all handle disruption in the same manner. \gls{DESAE}, for example, does not
 allow shutdown due to insufficient feedstock. In the event
@@ -23,32 +72,3 @@ of insufficient fissile material during reprocessing, \gls{DESAE} borrows
 material from storage, leaving a negative value \cite{mccarthy_benchmark_2012}.
 The \Cyclus framework does not dictate such heuristics. Rather, it provides a
 flexible framework on which either method is possible.
-
-\subsubsection{Open Access}
-
-The proprietary concerns of research institutions and security constraints of
-data within fuel cycle simulators often restrict access. Use of a simulator is
-therefore often limited to its institution of origin, necessitating effort
-duplication at other institutions and thereby squandering broader human
-resources. License agreements and institutional approval are required for most
-current simulators (i.e. \gls{COSI}6, \gls{DANESS}, \gls{DESAE}, EVOLCODE,
-FAMILY21, \gls{NFCSim})\cite{juchau_modeling_2010}, ORION, and VISION.  Even when, as in
-the case of the MIT \gls{CAFCA} software, the source code is unrestricted, the
-platform on which it relies is often restricted or commercial.  However, \Cyclus
-provides fully free and open access to all users
-and developers, foreign and domestic.
-
-\subsubsection{Flexibility and Extensibility}
-
-In addition to being inaccessible, the vast majority of fuel cycle simulators
-are, effectively, inextensible. Typical fuel cycle simulator development teams are insular, in
-part due to aforementioned accessibility issues. Accordingly, their frameworks
-typically contain heuristics and assumptions that constrain developer additions.
-
-For example, most current simulators describe a finite set of acceptable
-cycle constructions (once through, single-pass, multi-pass). That limits the
-capability to create novel material flows and economic scenarios. The \Cyclus
-simulation logic relies on a market paradigm, parameterized by the user, which
-flexibly simulates dynamic responses to pricing, availability, and other
-institutional preferences. This is an advanced level of flexibility that does
-not exist in other fuel cycle simulators.

--- a/fundamentals/fcsreqs.tex
+++ b/fundamentals/fcsreqs.tex
@@ -7,7 +7,7 @@ therefore often limited to its institution of origin, necessitating effort
 duplication at other institutions and thereby squandering broader human
 resources. License agreements and institutional approval are required for most
 current simulators (i.e. \gls{COSI}6, \gls{DANESS}, \gls{DESAE}, EVOLCODE,
-FAMILY21, \gls{NFCSim})\cite{juchau_modeling_2010}, ORION, and VISION.  Even when, as in
+FAMILY21, \gls{NFCSim})\cite{juchau_modeling_2010}, ORION, and \gls{VISION}.  Even when, as in
 the case of the MIT \gls{CAFCA} software, the source code is unrestricted, the
 platform on which it relies is often restricted or costly.  However, \Cyclus
 provides fully free and open access to all users

--- a/fundamentals/intro.tex
+++ b/fundamentals/intro.tex
@@ -141,7 +141,7 @@ generality and an extensible interface to facilitate collaboration.  The
 implementing increased modularity and encapsulation.  The result is a dynamic
 simulator that treats both materials and facilities discretely, with an
 architecture that permits multiple and variable levels of fidelity. The
-simulator's agent-based framework for tracking the transformation and tradef
+simulator's agent-based framework for tracking the transformation and trade of
 resources between autonomous regional and institutional entities with
 customizable behavior and objectives is an innovation not pursued by any
 existing fuel cycle simulator.
@@ -154,13 +154,17 @@ existing fuel cycle simulator.
 % \Cyclus, a hero, came in to fill that gap.
 
 The \Cyclus paradigm enables targeted contribution and collaboration within the
-nuclear fuel cycle analysis community. This essential capability is absent in
+nuclear fuel cycle analysis community to achieve two important goals: lower the
+barrier for innvoative nuclear technologies to be included in fuel cycle analysis 
+while improving the ability to compare simulations with and without those innovative
+concepts.  This essential capability is absent in
 previous simulators where user customization and extensibility were not design
-objectives, and was attained by the \emph{modular and open architecture} of
-\Cyclus.  Additionally, \Cyclus facilitates direct comparison of modeling
-methodologies with \emph{agent interchangeability}.  Finally, \Cyclus is
+objectives.  While the \emph{modular and open architecture} of
+\Cyclus is necessary to meet these goals, it is not sufficient.  
+\emph{Agent interchangeability} is required to facilitates direct comparison 
+of alternative modeling methodologies and facility concepts.  Finally, \Cyclus is
 applicable to a broader range of fidelities, scales, and applications than
-other simulators.  due to the flexibility and generality of its
+other simulators, due to the flexibility and generality of its
 \emph{\gls{ABM}} paradigm and \emph{discrete, object-oriented approach}.
 
 This structure recognizes that specialists should utilize their time and


### PR DESCRIPTION
I propose this set of changes separately(*) because it presents a substantial reframing of this section.  It may be subject to discussion and I am look forward to such discussions if anyone feels that I've changed things too much on any axis.

There are a number of goals for these changes:

* further promote the fuel cycle analysis reasons for flexibility & extensibility as motivations
* a slightly more positive (about us) than negative (about others) tone
* stronger highlighting of the DRE
* expand open access to include development practices
* promote role of modularity in agent interchangeability as key innovation, enabled by DRE

(*) I have made this PR largely independent of others, although there are a couple of small typos that also are corrected in #80 