### PR TITLE
incorporates some @flanflanagan suggestions

### DIFF
--- a/fundamentals/conclusion.tex
+++ b/fundamentals/conclusion.tex
@@ -28,7 +28,7 @@ simulation capability. It allows \Cyclus to address common analyses in a more
 flexible fashion and enables analyses that are impossible with system dynamics
 simulators.
 
-Similarly the fidelity-agnostic modular architecture facilitates simulations
+Similarly, the fidelity-agnostic, modular \Cyclus architecture facilitates simulations
 at every level of detail. Simulations relying on arbitrarily complex isotopic
 compositions are possible in \Cyclus, as are simulations not employing any
 physics at all. Indeed, agents of such varying fidelity can even exist in the

--- a/fundamentals/conclusion.tex
+++ b/fundamentals/conclusion.tex
@@ -28,7 +28,7 @@ simulation capability. It allows \Cyclus to address common analyses in a more
 flexible fashion and enables analyses that are impossible with system dynamics
 simulators.
 
-Similarly, discrete, fidelity-agnostic object tracking facilitates simulations
+Similarly the fidelity-agnostic modular architecture facilitates simulations
 at every level of detail. Simulations relying on arbitrarily complex isotopic
 compositions are possible in \Cyclus, as are simulations not employing any
 physics at all. Indeed, agents of such varying fidelity can even exist in the

--- a/fundamentals/conclusion.tex
+++ b/fundamentals/conclusion.tex
@@ -17,11 +17,11 @@
 %Enables apples to apples comparisons
 
 The \Cyclus nuclear fuel cycle framework presents a more generic and flexible
-alternative to existing fuel cycle simulators. Where previous nuclear fuel cycle simulators have had limited distribution,
-constrained simulation capabilities, and restricted customizability, \Cyclus emphasizes an
-open strategy for access and development.  This open strategy, with transparent
-publication of the source code, not only provides much-needed accessibility,
-but also enables transparency and community oversight.
+alternative to existing fuel cycle simulators. Where previous nuclear fuel
+cycle simulators have had limited distribution, constrained simulation
+capabilities, and restricted customizability, \Cyclus emphasizes an open
+strategy for access and development.  This open strategy not only improves
+accessibility, but also enables transparency and community oversight.
 
 The object-oriented \gls{ABM} simulation paradigm ensures more generic
 simulation capability. It allows \Cyclus to address common analyses in a more

--- a/fundamentals/conclusion.tex
+++ b/fundamentals/conclusion.tex
@@ -19,7 +19,7 @@
 The \Cyclus nuclear fuel cycle framework presents a more generic and flexible
 alternative to existing fuel cycle simulators. Where previous nuclear fuel cycle simulators have had limited distribution,
 constrained simulation capabilities, and restricted customizability, \Cyclus emphasizes an
-open access and development strategy.  Open development, with transparent
+open strategy for access and development.  This open strategy, with transparent
 publication of the source code, not only provides much-needed accessibility,
 but also enables transparency and community oversight.
 

--- a/fundamentals/intro.tex
+++ b/fundamentals/intro.tex
@@ -26,7 +26,7 @@ efforts to directly compare modeling methodologies. Finally, they
 over-specialize, rendering most tools applicable to only a subset of desired
 simulation fidelities, scales, and applications.
 
-The cardinal purpose of a dyamic nuclear fuel cycle simulator is to calculate
+The cardinal purpose of a dynamic nuclear fuel cycle simulator is to calculate
 the time- and facility-dependent mass flow through all or part the fuel cycle.
 Dynamic nuclear fuel cycle analysis more realistically supports a range of
 simulation goals than static analysis \cite{piet_dynamic_2011}. Historically,
@@ -104,7 +104,7 @@ some simulators discretely model batches of material and individual facilities,
 others aggregate facilities into fleets and materials into streams. Simulators
 can model a single aspect of the fuel cycle in great detail while neglecting
 others. For example, a simulator created for policy modeling might have
-excellent capability in economics while capabailities for tracking transformations in
+excellent capability in economics while capabilities for tracking transformations in
 material isotopics and the effects of isotopics on technology performance are
 neglected.  The \gls{CAFCA}\cite{guerin_impact_2009} simulator is problem-oriented
 in this way, having elected to neglect isotopic resolution in favor of
@@ -154,7 +154,7 @@ cycle simulator.
 
 The \Cyclus paradigm enables targeted contribution and collaboration within the
 nuclear fuel cycle analysis community to achieve two important goals: lower the
-barrier for innvoative nuclear technologies to be included in fuel cycle analysis
+barrier for innovative nuclear technologies to be included in fuel cycle analysis
 while improving the ability to compare simulations with and without those innovative
 concepts.  This essential capability is absent in
 previous simulators where user customization and extensibility were not design

--- a/fundamentals/intro.tex
+++ b/fundamentals/intro.tex
@@ -154,13 +154,13 @@ cycle simulator.
 
 The \Cyclus paradigm enables targeted contribution and collaboration within the
 nuclear fuel cycle analysis community to achieve two important goals: lower the
-barrier for innvoative nuclear technologies to be included in fuel cycle analysis 
+barrier for innvoative nuclear technologies to be included in fuel cycle analysis
 while improving the ability to compare simulations with and without those innovative
 concepts.  This essential capability is absent in
 previous simulators where user customization and extensibility were not design
 objectives.  While the \emph{modular and open architecture} of
-\Cyclus is necessary to meet these goals, it is not sufficient.  
-\emph{Agent interchangeability} is required to facilitates direct comparison 
+\Cyclus is necessary to meet these goals, it is not sufficient.
+\emph{Agent interchangeability} is required to facilitates direct comparison
 of alternative modeling methodologies and facility concepts.  Finally, \Cyclus is
 applicable to a broader range of fidelities, scales, and applications than
 other simulators, due to the flexibility and generality of its
@@ -172,9 +172,10 @@ expertise (e.g., reprocessing and advanced fuel fabrication), without having to
 create a model of the entire fuel cycle to serve as its host.  \Cyclus supports
 them by separating the problem of modeling a physics-dependent supply chain into
 two distinct components: a simulation kernel and archetypes that interact with
-the kernel. The kernel is responsible for supporting the deployment and
+it. The kernel is responsible for supporting the deployment and
 interaction logic of entities in the simulation.  Physics calculations and
-customized behaviors are implemented within archetypes.
+customized behaviors of those entities are implemented within \emph{archetype}
+classes.
 
 Ultimately, modeling the evolution of a physics-dependent, international
 nuclear fuel supply chain is a multi-scale problem which existing tools cannot


### PR DESCRIPTION
incorporates some @flanflanagan suggestions:

```
Intro 

Line 55 ish : 
\Cyclus, is a dynamic, agent-based model, which employs a modular architecture,
an open development process, discrete agents, discrete time, and arbitrarily
detailed isotopic resolution of materials. -I am not sure what you mean by arbitrarily detailed isotopic resolution. I was under the impression that materials had a set level of detail. 


Examples

Line 53 - I noticed 'archetypes' being used a lot around this area. Perhaps a definition could be helpful. I know the termonology of cyclus was a bit confusing to me when I first started. 


Conclusions
Line 22 - :
\Cyclus emphasizes an
open access and development strategy. - I think I understand what you are trying to say here. You mean access and development are open. Put another way an open(access + development) strategy. Is this correct?

Line 23 ish :
 Open development, with transparent publication of the source code, not only provides much-needed accessibility,
but also enables transparency and community oversight. - This seems a bit redundant. Maybe something like 'This strategy not only improves accessibility but also enables transparency and community oversite.'

Line 31 :
Similarly, discrete, fidelity-agnostic object tracking facilitates  - So, I'm not sure what is meant by object tracking. I understand what this paragraph is trying to highlight but this sentence is really throwing me off. 

```