### PR TITLE
I think this solves #85 with the 'changing all the text' strategy.

### DIFF
--- a/fundamentals/impl.tex
+++ b/fundamentals/impl.tex
@@ -90,7 +90,7 @@ capabilities independent of the core.
 \begin{center}
 \includegraphics[width=\textwidth]{./images/framework}
 \end{center}
-\caption{The \Cyclus core provides \gls{API}s that abstract away the details in
+\caption{The \Cyclus core provides \glspl{API} that abstract away the details in
 the kernel and allow the archetypes to be loaded into the simulation in a modular
 fashion.}
 \label{fig:framework}
@@ -180,8 +180,8 @@ all necessary functionality for interacting with the \Cyclus simulation kernel.
 \begin{center}
 \includegraphics[width=0.5\textwidth]{./images/agent_uml}
 \end{center}
-\caption{The inheritance in \Cyclus classes, such as the \Class{Agent},
-\Class{Facility}, \Class{Institution}, and \Class{Region} classes, abstract away
+\caption{Inheriting \Cyclus class interfaces, such as the \Class{Agent},
+\Class{Facility}, \Class{Institution}, and \Class{Region} classes, abstracts away
 unnecessary details while exposing powerful functionality. In the above
 example, the \Class{Dummy} archetype simply inherits from \Class{Region} in
 order to become a bona fide Region-type \Class{Agent}.}

--- a/fundamentals/impl.tex
+++ b/fundamentals/impl.tex
@@ -168,17 +168,13 @@ implementation of a reactor can be compared to an implementation with higher
 physics fidelity, allowing an analyst to discern the effect of reactor physical
 fidelity on a given fuel cycle.
 
-Interchangeability is accomplished by providing \glspl{API} that define agent-to-agent
-interaction and agent-to-environment interaction, primarily through the
-\Class{Agent} and \Class{Trader} interfaces. Figure \ref{fig:agent_uml} shows
-the ``inheritance'' structure of the \Class{Agent} class in a \gls{UML} diagram
-format. It shows how the \Class{Agent} interface
-provides a notion of parent-child hierarchical relationship, where parents can
-choose to \textit{deploy} child agents and \textit{decommission} child
-agents. For the archetype developer, this interface provides enormous power
-very simply. The \gls{API} provides the \Class{Agent} with helpful functionality for
-interacting with the \Cyclus simulation kernel while abstracting away unnecessary
-detail.
+Interchangeability is accomplished by providing inheritable \glspl{API} that define agent-to-agent
+interaction and agent-to-environment interaction. For example,
+an archetype that inherits the \Class{Region} interface, as in Figure
+\ref{fig:agent_uml}, is interchangeable with any other Region agent.
+For the archetype developer, this interface provides enormous power
+very simply. The \gls{API} abstracts away unnecessary detail while providing
+all necessary functionality for interacting with the \Cyclus simulation kernel.
 
 \begin{figure}[htbp!]
 \begin{center}


### PR DESCRIPTION
I think this solves #85 with the 'changing all the text' strategy. It also gets rid of untrue claims about what the diagram shows and tries to avoid introducing the names of classes not yet explained.