### PR TITLE
Fix French, because french is horrible and sooooo complicated. 

### DIFF
--- a/fundamentals/acros.tex
+++ b/fundamentals/acros.tex
@@ -51,7 +51,7 @@
 \newacronym{HTGR}{HTGR}{high temperature gas reactor}
 \newacronym{TRISO}{TRISO}{Tristructural Isotropic}
 \newacronym{MA}{MA}{minor actinide}
-\newacronym{CEA}{CEA}{Commissariat a l'\'Energie Atomique et aux \'Energies Alternatives}
+\newacronym{CEA}{CEA}{Commissariat \`a l'\'Energie Atomique et aux \'Energies Alternatives}
 \newacronym{SKB}{SKB}{Svensk Karnbranslehantering AB}
 \newacronym{SINDAG}{SINDA{\textbackslash}G}{Systems Improved Numerical Differencing Analyzer $\backslash$ Gaski}
 \newacronym{STC}{STC}{specific temperature change}

--- a/fundamentals/acros.tex
+++ b/fundamentals/acros.tex
@@ -51,7 +51,7 @@
 \newacronym{HTGR}{HTGR}{high temperature gas reactor}
 \newacronym{TRISO}{TRISO}{Tristructural Isotropic}
 \newacronym{MA}{MA}{minor actinide}
-\newacronym{CEA}{CEA}{Commissariat a l'Energie Atomique et aux Energies Alternatives}
+\newacronym{CEA}{CEA}{Commissariat a l'\'Energie Atomique et aux \'Energies Alternatives}
 \newacronym{SKB}{SKB}{Svensk Karnbranslehantering AB}
 \newacronym{SINDAG}{SINDA{\textbackslash}G}{Systems Improved Numerical Differencing Analyzer $\backslash$ Gaski}
 \newacronym{STC}{STC}{specific temperature change}


### PR DESCRIPTION
Add accent on "Énergie(s)"

Because even if most French do not know how to put accent on
upper case letters, it is not a reason not to do it.

Fix accent on French acronym description
- `a` is the equivalent of `belong to`/`has a`
- `à` if the equivalent of `of`

The comity likely does not belong to, or has a member who is nucléar
energy.

Simpler explanation, do as
[Wikipedia does](https://fr.wikipedia.org/wiki/Commissariat_%C3%A0_l%27%C3%A9nergie_atomique_et_aux_%C3%A9nergies_alternatives)
## 

Seen during @katyhuff THW, who BTW has a terrible french accent :-P . I'm sure you can criticize my english. 
